### PR TITLE
Add Ansible roles and collections installation step

### DIFF
--- a/.github/workflows/ansible-validation.yml
+++ b/.github/workflows/ansible-validation.yml
@@ -31,6 +31,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install ansible ansible-lint yamllint
 
+      - name: Install Ansible roles and collections
+        run: |
+          echo "Installing Ansible collections..."
+          ansible-galaxy collection install -r ansible/requirements.yml
+          echo "Installing Ansible roles..."
+          ansible-galaxy role install -r ansible/requirements.yml
+
       - name: Validate YAML syntax
         run: |
           echo "Validating YAML files..."
@@ -39,7 +46,7 @@ jobs:
       - name: Validate Ansible syntax
         run: |
           echo "Checking Ansible playbook syntax..."
-          ansible-playbook --syntax-check ansible/wireguard-server.yml || true
+          ansible-playbook --syntax-check ansible/wireguard-server.yml
 
       - name: Validate requirements.yml structure
         run: |
@@ -147,7 +154,7 @@ jobs:
       - name: Run ansible-lint
         run: |
           echo "Running ansible-lint..."
-          ansible-lint ansible/wireguard-server.yml || echo "⚠️ ansible-lint found issues (non-blocking)"
+          ansible-lint ansible/wireguard-server.yml
 
       - name: Validation summary
         if: success()
@@ -162,4 +169,5 @@ jobs:
           echo "  ✅ Ansible syntax check"
           echo "  ✅ requirements.yml structure validation"
           echo "  ✅ Playbook references validation"
+          echo "  ✅ ansible-lint checks"
           echo ""

--- a/ansible/wireguard-server.yml
+++ b/ansible/wireguard-server.yml
@@ -4,10 +4,10 @@
   gather_facts: false
   tasks:
     - name: Generate random octets
-      set_fact:
+      ansible.builtin.set_fact:
         random_octets: "{{ 254 | random }}.{{ 254 | random }}"
     - name: Display IP info
-      debug:
+      ansible.builtin.debug:
         msg: "The generated random /24 subnet is 10.{{ random_octets }}.0/24"
 
 - name: Wireguard deployment
@@ -34,13 +34,15 @@
     wireguard_address: "10.{{ hostvars['localhost'].random_octets }}.0/24"
 
   tasks:
+
     - name: Perform steps on host
       when: ansible_facts['os_family'] == 'Debian'
       block:
+
         - name: Update cache and upgrade all packages on Debian server
           ansible.builtin.apt:
             name: "*"
-            state: latest
+            state: latest  # noqa package-latest
             update_cache: true
             cache_valid_time: 3600
           register: apt_output
@@ -48,7 +50,9 @@
           retries: 30
           delay: 15
           ignore_errors: true
-        - debug: var=apt_output.stdout_lines
+        - name: Display apt output
+          ansible.builtin.debug:
+            var: apt_output.stdout_lines
 
         - name: Check if reboot required
           ansible.builtin.stat:
@@ -63,7 +67,7 @@
             pre_reboot_delay: 0
             post_reboot_delay: 30
             test_command: uptime
-          when: reboot_required_file.stat.exists == true
+          when: reboot_required_file.stat.exists
 
         - name: Remove dependencies that are no longer required
           ansible.builtin.apt:
@@ -116,7 +120,7 @@
           ansible.builtin.template:
             src: templates/wg-server.j2
             dest: "/etc/wireguard/wg0.conf"
-            mode: 0600
+            mode: "0600"
             force: true
 
         - name: Add rule for 51820 UDP


### PR DESCRIPTION
Add steps to install Ansible roles and collections using `ansible-galaxy` based on `ansible/requirements.yml` so we actually check if the roles and collections have correct syntax

Validation and linting enforcement:
* Removed the `|| true` from the Ansible syntax check step, so the workflow will now fail if a syntax error is found, making the check blocking instead of non-blocking
* Made `ansible-lint` a blocking check by removing the logic that allowed the workflow to continue when lint issues are found
* Updated the validation summary to include a line indicating that `ansible-lint` checks were performed